### PR TITLE
Fix fft_filter on multi-channel input; clarify filter_by_key & LowFrequencyFilter docstrings

### DIFF
--- a/brainmaze_utils/annotations/_utils.py
+++ b/brainmaze_utils/annotations/_utils.py
@@ -317,7 +317,13 @@ def filter_by_duration(dfAnnotations: pd.DataFrame, duration: Union[int, float])
 
 def filter_by_key(dfAnnotations: pd.DataFrame, key: str, value: Union[int, float]):
     """
-    Keeps only annotations given by the key and value within the pandas DataFrame
+    Removes annotations whose ``key`` column equals ``value``, keeping all others.
+
+    Note
+    ----
+    This *drops* the rows matching ``value`` (the inverse of what the name may suggest);
+    e.g. ``filter_by_key(df, 'annotation', 'Arrousal')`` returns the frame with arousals
+    removed.
     """
     return dfAnnotations.loc[dfAnnotations[key] != value].reset_index(drop=True)
 

--- a/brainmaze_utils/annotations/_utils.py
+++ b/brainmaze_utils/annotations/_utils.py
@@ -315,7 +315,7 @@ def filter_by_duration(dfAnnotations: pd.DataFrame, duration: Union[int, float])
     dfAnnotations = dfAnnotations.loc[dfAnnotations['duration'] == duration].reset_index(drop=True)
     return dfAnnotations
 
-def filter_by_key(dfAnnotations: pd.DataFrame, key: str, value: Union[int, float]):
+def filter_by_key(dfAnnotations: pd.DataFrame, key: str, value: Union[int, float, str]):
     """
     Removes annotations whose ``key`` column equals ``value``, keeping all others.
 

--- a/brainmaze_utils/signal.py
+++ b/brainmaze_utils/signal.py
@@ -245,9 +245,13 @@ def fft_filter(X:np.ndarray, fs:float, cutoff:float, type:str='lp'):
     """
     FFT filter
 
+    Filters along the last axis, so a 2-D array of shape ``(n_signals, n_samples)`` is
+    filtered per-signal.
+
     Parameters
     ----------
     X : numpy.ndarray
+        Signal ``(n_samples,)`` or a stack of signals ``(..., n_samples)``.
     fs : float
     cutoff : float
     type : str
@@ -256,21 +260,29 @@ def fft_filter(X:np.ndarray, fs:float, cutoff:float, type:str='lp'):
     Returns
     -------
     numpy.ndarray
+        Same shape as ``X``.
 
     """
+    if type not in ('lp', 'hp'):
+        raise ValueError(f"type must be 'lp' or 'hp', got {type!r}")
 
-    Xs = fft.fft(X)
-    freq = np.linspace(0, fs, Xs.shape[0])
-    pos = np.where(freq > cutoff)[0][0]
+    n_samples = X.shape[-1]
+    Xs = fft.fft(X, axis=-1)
+    freq = np.linspace(0, fs, n_samples)
+    above = np.where(freq > cutoff)[0]
+    if above.size == 0:  # cutoff at or above the top bin -> nothing above it to remove
+        stop = pos = n_samples
+    else:
+        pos = int(above[0])
+        stop = n_samples - pos  # symmetric upper bound == original [pos:-pos]
 
     if type == 'lp':
-        X_new = Xs
-        X_new[pos:-pos] = 0
-    elif type == 'hp':
+        X_new = Xs.copy()
+        X_new[..., pos:stop] = 0
+    else:  # 'hp'
         X_new = np.zeros_like(Xs)
-        X_new[pos:-pos] = Xs[pos:-pos]
-    X = np.real(fft.ifft(X_new))
-    return X
+        X_new[..., pos:stop] = Xs[..., pos:stop]
+    return np.real(fft.ifft(X_new, axis=-1))
 
 def buffer(x:np.ndarray, fs:float=1, segm_size:float=None, overlap:float = 0, drop:bool=True):
     """
@@ -390,16 +402,28 @@ class LowFrequencyFilter:
         dec_cutoff : float
             relative frequency at which the signal will be filtered when downsampled
         filter_type : str
-            'lp' or 'hp'
+            Which side of ``cutoff`` is returned:
+
+            - ``'lp'`` returns the low-frequency content **below** ``cutoff``.
+            - ``'hp'`` returns ``x`` minus that low-frequency content, i.e. the
+              high-frequency content **above** ``cutoff`` (use this to remove slow drift).
+
+            Pick the one that matches the content you want to keep -- see the examples.
         ftype : str
             'fir' or 'iir'
 
 
         .. code-block:: python
 
-            LFFilter = LowFrequencyFilter(fs=fs, cutoff=cutoff_low, n_decimate=2, n_order=101, dec_cutoff=0.3, filter_type='lp')
-            X_inp = np.random.randn(1e4)
-            X_outp = LFilter(X_inp)
+            x = np.random.randn(10000)
+
+            # keep slow content below the cutoff (e.g. isolate drift / a slow oscillation)
+            lowpass = LowFrequencyFilter(fs=fs, cutoff=cutoff, n_decimate=2, n_order=101, filter_type='lp')
+            x_slow = lowpass(x)
+
+            # remove slow drift, keeping content above the cutoff
+            highpass = LowFrequencyFilter(fs=fs, cutoff=cutoff, n_decimate=2, n_order=101, filter_type='hp')
+            x_detrended = highpass(x)
     """
 
     __version__ = '0.0.2'

--- a/brainmaze_utils/signal.py
+++ b/brainmaze_utils/signal.py
@@ -265,6 +265,10 @@ def fft_filter(X:np.ndarray, fs:float, cutoff:float, type:str='lp'):
     """
     if type not in ('lp', 'hp'):
         raise ValueError(f"type must be 'lp' or 'hp', got {type!r}")
+    if fs <= 0:
+        raise ValueError(f"fs must be > 0, got {fs!r}")
+    if cutoff < 0:
+        raise ValueError(f"cutoff must be >= 0, got {cutoff!r}")
 
     n_samples = X.shape[-1]
     Xs = fft.fft(X, axis=-1)

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -48,3 +48,13 @@ def test_tile_annotations():
 
 
 
+
+
+def test_filter_by_key_removes_matching_rows():
+    # documents the actual behaviour: rows equal to `value` are DROPPED, others kept
+    from brainmaze_utils.annotations import filter_by_key
+    df = pd.DataFrame({'annotation': ['AWAKE', 'Arrousal', 'N2', 'Arrousal'],
+                       'start': [0, 1, 2, 3]})
+    out = filter_by_key(df, 'annotation', 'Arrousal')
+    assert list(out['annotation']) == ['AWAKE', 'N2']
+    assert list(out['start']) == [0, 2]

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -163,3 +163,67 @@ def test_signal_not_multiple_of_window_size():
     np.testing.assert_array_equal(downsampled_signal, expected_downsampled_signal)
     assert len(downsampled_signal) == expected_output_length
     assert actual_fs == pytest.approx(expected_actual_fs)
+
+
+# --------------------------------------------------------------------------------------
+# fft_filter
+# --------------------------------------------------------------------------------------
+from brainmaze_utils.signal import fft_filter
+
+_FS = 200.0
+_T = np.arange(0, 10, 1 / _FS)
+_LOW = np.sin(2 * np.pi * 2 * _T)     # 2 Hz  -> passes a 4 Hz lowpass
+_HIGH = np.sin(2 * np.pi * 30 * _T)   # 30 Hz -> removed by a 4 Hz lowpass
+
+
+@pytest.mark.parametrize('kind', ['lp', 'hp'])
+def test_fft_filter_isolates_the_right_band_1d(kind):
+    out = fft_filter(_LOW + _HIGH, _FS, 4, kind)
+    keep, drop = (_LOW, _HIGH) if kind == 'lp' else (_HIGH, _LOW)
+    # the kept component survives; the rejected one is gone
+    assert np.corrcoef(out, keep)[0, 1] > 0.99
+    assert np.abs(fft_filter(drop, _FS, 4, kind)).max() < 1e-6
+
+
+@pytest.mark.parametrize('kind', ['lp', 'hp'])
+def test_fft_filter_2d_is_per_channel(kind):
+    X = np.vstack([_LOW, _HIGH])
+    out = fft_filter(X, _FS, 4, kind)
+    expected = np.vstack([fft_filter(_LOW, _FS, 4, kind),
+                          fft_filter(_HIGH, _FS, 4, kind)])
+    assert out.shape == X.shape
+    np.testing.assert_allclose(out, expected, atol=1e-12)
+
+
+def test_fft_filter_2d_lowpass_removes_out_of_band_channel():
+    # regression: a 30 Hz channel must be annihilated by a 4 Hz lowpass, not passed through
+    X = np.vstack([_LOW, _HIGH])
+    out = fft_filter(X, _FS, 4, 'lp')
+    assert np.abs(out[0]).max() > 0.9    # 2 Hz kept
+    assert np.abs(out[1]).max() < 1e-6   # 30 Hz removed
+
+
+def test_fft_filter_nd_matches_per_signal():
+    rng = np.random.default_rng(0)
+    X = rng.normal(size=(2, 3, _T.size))
+    out = fft_filter(X, _FS, 4, 'hp')
+    expected = np.stack([[fft_filter(X[i, j], _FS, 4, 'hp') for j in range(3)]
+                         for i in range(2)])
+    np.testing.assert_allclose(out, expected, atol=1e-12)
+
+
+def test_fft_filter_cutoff_at_or_above_nyquist_does_not_raise():
+    np.testing.assert_allclose(fft_filter(_LOW, _FS, 150, 'lp'), _LOW, atol=1e-9)
+    np.testing.assert_allclose(fft_filter(_LOW, _FS, 150, 'hp'), 0.0, atol=1e-9)
+
+
+def test_fft_filter_rejects_unknown_type():
+    with pytest.raises(ValueError):
+        fft_filter(_LOW, _FS, 4, 'bandpass')
+
+
+def test_fft_filter_does_not_mutate_input():
+    x = (_LOW + _HIGH).copy()
+    before = x.copy()
+    fft_filter(x, _FS, 4, 'lp')
+    np.testing.assert_array_equal(x, before)


### PR DESCRIPTION
Closes #18, #19, #20, #21.

## `fft_filter` silently wrong on 2-D input (#18, #19)

`fft_filter` built its frequency axis from `Xs.shape[0]` and zeroed `X_new[pos:-pos]` along **axis 0**. For a `(n_channels, n_samples)` array that is the channel axis, so it filtered *across channels* instead of across time — returning a wrong result with **no error**.

```python
ch0 = sin(2π·2·t)    # 2 Hz  -> should pass a 4 Hz lowpass
ch1 = sin(2π·30·t)   # 30 Hz -> should be removed
X   = np.vstack([ch0, ch1])

# before: per-channel max amplitude [1.0, 1.0]  <- 30 Hz channel passed straight through
# after : per-channel max amplitude [1.0, 0.0]  <- correct
```

Now filters along the **last axis** throughout:

- **1-D output is bit-identical** to the previous implementation (verified against a reconstruction of the old `[pos:-pos]` logic across `lp`/`hp` and several cutoffs).
- `(…, n_samples)` stacks (2-D, N-D) filter **per-signal**.
- `cutoff >= Nyquist` no longer raises `IndexError` (lowpass returns the input, highpass returns ~0).
- Unknown `type` now raises `ValueError` instead of silently returning the FFT input unfiltered.

This repo shipped no 2-D callers, but downstream code did; see bnelair/brainmaze-eeg#35 context.

## Docstring fixes

- **`filter_by_key` (#20):** docstring said *"Keeps only annotations given by the key and value"* but the code is `!= value` — it **removes** matching rows. Callers depend on the remove behaviour, so the docstring was corrected (code unchanged) and a behaviour-pinning test added.
- **`LowFrequencyFilter` (#21):** the usage example only showed `filter_type="lp"`. It was copy-pasted verbatim into `brainmaze-eeg`s `WaveDetector`, where `"hp"` (drift removal) was needed — shipping a silent bug (bnelair/brainmaze-eeg#35). The docstring now explains which side of `cutoff` each mode returns and shows both.

## Tests

`31 passed` in `test_signal.py` (7 new `fft_filter` tests: per-channel 2-D/N-D correctness, the 30 Hz-removal regression, 1-D equivalence via band isolation, Nyquist edge, bad-type, non-mutation) and a new `filter_by_key` behaviour test. No existing test changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)