### PR TITLE
Adopt PR-based release flow (no push to protected main) + version guard + docs

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,24 @@
+name: Prepare release
+
+# Opens a "Release vX.Y.Z" pull request that bumps [project].version in pyproject.toml.
+# A code owner reviews and merges it; merging to main triggers Release (release.yml).
+# This never pushes to a protected branch. See the shared workflow for details.
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Version bump"
+        type: choice
+        options: [patch, minor, major]
+        default: patch
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  prepare:
+    uses: bnelair/brainmaze-sphinx/.github/workflows/prepare-release.yml@main
+    with:
+      bump: ${{ inputs.bump }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,12 @@
 name: Release
 
+# Runs on every push to main but only releases when the current pyproject version has no
+# tag yet -- i.e. right after a "Release vX.Y.Z" bump PR is merged. Ordinary dev -> main
+# feature merges leave the version unchanged and therefore no-op. Never writes to main.
+
 on:
-  workflow_dispatch:
-    inputs:
-      bump:
-        description: "Version bump"
-        type: choice
-        options: [patch, minor, major]
-        default: patch
+  push:
+    branches: [main]
 
 permissions:
   contents: write
@@ -17,7 +16,6 @@ jobs:
   release:
     uses: bnelair/brainmaze-sphinx/.github/workflows/release.yml@main
     with:
-      bump: ${{ inputs.bump }}
       pypi-auth: trusted
     secrets:
       PYPI_Token_General: ${{ secrets.PYPI_Token_General }}

--- a/.github/workflows/version-guard.yml
+++ b/.github/workflows/version-guard.yml
@@ -1,0 +1,32 @@
+name: Version guard
+
+# Enforces that [project].version is only ever changed by the release flow (the
+# release/bump-* branch opened by "Prepare release"). Any other PR that edits the version
+# fails, which keeps the version line owned solely by the release automation on main and
+# therefore keeps dev -> main merges free of version conflicts under squash merges.
+
+on:
+  pull_request:
+    branches: [main, dev]
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Reject version edits outside the release flow
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.head_ref }}" == release/bump-* ]]; then
+            echo "Release bump PR -- version change allowed."
+            exit 0
+          fi
+          base='${{ github.event.pull_request.base.sha }}'
+          if git diff "$base" HEAD -- pyproject.toml | grep -qE '^[+-][[:space:]]*version[[:space:]]*='; then
+            echo "::error::This PR changes [project].version in pyproject.toml. The version is owned by the release automation on main -- use the 'Prepare release' action instead. See the README 'How to contribute' section."
+            exit 1
+          fi
+          echo "No version change -- OK."

--- a/.github/workflows/version-guard.yml
+++ b/.github/workflows/version-guard.yml
@@ -1,9 +1,11 @@
 name: Version guard
 
-# Enforces that [project].version is only ever changed by the release flow (the
-# release/bump-* branch opened by "Prepare release"). Any other PR that edits the version
-# fails, which keeps the version line owned solely by the release automation on main and
-# therefore keeps dev -> main merges free of version conflicts under squash merges.
+# Enforces that [project].version is only ever changed by the release flow. The exemption
+# requires all three signals of a genuine release bump -- opened by github-actions[bot],
+# from a release/bump-* branch, targeting main -- so a hand-named branch cannot slip a
+# version edit past the check. This keeps the version line owned solely by the release
+# automation on main and therefore keeps dev -> main merges free of version conflicts
+# under squash merges.
 
 on:
   pull_request:
@@ -20,8 +22,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if [[ "${{ github.head_ref }}" == release/bump-* ]]; then
-            echo "Release bump PR -- version change allowed."
+          if [[ "${{ github.event.pull_request.base.ref }}" == "main" \
+                && "${{ github.head_ref }}" == release/bump-* \
+                && "${{ github.event.pull_request.user.login }}" == "github-actions[bot]" ]]; then
+            echo "Automated release bump PR -- version change allowed."
             exit 0
           fi
           base='${{ github.event.pull_request.base.sha }}'

--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,15 @@ The project has 2 main protected branches *main* that contains official software
 To implement a new feature a new branch should be created from the *dev* branch with name pattern of *developer_identifier/feature_name*.
 
 After the feature is implemented, a pull request can be created to merge the feature branch into the *dev* branch with. Pull requests need to be reviewed by the code owners.
-Drafting of new releases will be performed by the code owners in using pull request from *dev* to *main* and drafting a new release on GitHub.
+
+Releasing
+'''''''''''''''''''''''''''''''
+
+Releases are automated and never bypass branch protection. To cut a release, a code owner runs the **Prepare release** GitHub Action (*Actions* tab, ``workflow_dispatch``) and selects the bump (*patch* / *minor* / *major*). This opens a small ``Release vX.Y.Z`` pull request that bumps ``[project].version`` in ``pyproject.toml`` on a ``release/bump-*`` branch off *main*. Once a code owner approves and merges that pull request into *main*, the **Release** workflow tags the version, builds the distributions, publishes to PyPI, and drafts the GitHub release automatically. The build reads the version from ``pyproject.toml``, which remains the single source of truth.
+
+Promotion of features from *dev* to *main* is independent of releases and **must not change** ``[project].version`` -- a *Version guard* CI check fails any pull request outside the release flow that edits it. The version line is owned solely by the release automation on *main*; this is what keeps ``dev`` -> ``main`` merges free of version conflicts under the squash-merge policy (a version edited on both branches would otherwise conflict every release cycle).
+
+The **Prepare release** action requires the repository/organization setting *Allow GitHub Actions to create and approve pull requests* to be enabled, so it can open the bump pull request.
 
 New functions need to be implemented with Sphinx compatible docstrings. The documentation is automatically generated from the docstrings using Sphinx.
 


### PR DESCRIPTION
Adopts the PR-based release flow (companion to bnelair/brainmaze-sphinx#1) so releasing no longer pushes to protected `main`. **Depends on that shared-workflow PR being merged first** (the callers here reference `bnelair/brainmaze-sphinx/.github/workflows/*@main`).

## What changes

- **`.github/workflows/prepare-release.yml`** (new, `workflow_dispatch`): pick a bump → opens a `Release vX.Y.Z` PR that edits `[project].version` on a `release/bump-*` branch off `main`.
- **`.github/workflows/release.yml`** (replaced): now triggers on **push to `main`** and delegates to the shared release workflow, which releases only when the current version has no tag yet. The old `workflow_dispatch`-with-`bump` version that pushed to `main` is gone.
- **`.github/workflows/version-guard.yml`** (new): fails any PR that edits `[project].version` outside a `release/bump-*` branch, so the version stays owned by the release automation on `main` (this is what keeps `dev → main` merges conflict-free under squash merges).
- **`README.rst`**: the *How to contribute* section gains a *Releasing* subsection documenting the flow and the version-ownership rule.

## How a release works now

1. Code owner runs **Prepare release** → approves & merges the `Release vX.Y.Z` PR into `main`.
2. That merge triggers **Release**: tag `vX.Y.Z` (tags aren't protected) → build → PyPI (Trusted Publishing) → GitHub Release. No push to `main`.

Static `version` in `pyproject.toml` stays the single source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
